### PR TITLE
tweak sendMessage function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/lib/winston-papertrail.js
+++ b/lib/winston-papertrail.js
@@ -293,7 +293,7 @@ class PapertrailTransport extends Transport {
           appName: this.options.program,
           date: new Date(),
           message: this.options.logFormat(level, gap + lines[i]),
-        }) + '\r\n';
+        }) + '\n';
     }
 
     this.connection.write(msg, callback);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "winston-3-papertrail",
+  "name": "winston-papertrail-mproved",
   "description": "A Papertrail transport for winston. Fork of http://github.com/kenperkins/winston-papertrail.git",
   "version": "1.0.7",
   "author": "Nishkal Kashyap <hello@nishkal.in>",


### PR DESCRIPTION
Hi, 
I think sending '\r\n' in the message is not necessary, '\n' is enough.
And it will cause a tiny issue. Every message sent to a standard rsyslog server will have a '# 015' escaped tail.
This fix will make it clean.